### PR TITLE
Update gradle plugin version to support Gradle 7.6

### DIFF
--- a/src/main/resources/init.gradle
+++ b/src/main/resources/init.gradle
@@ -3,7 +3,7 @@ initscript {
         maven { url "https://plugins.gradle.org/m2" }
     }
     dependencies {
-        classpath "com.dorongold.plugins:task-tree:2.1.0"
+        classpath "com.dorongold.plugins:task-tree:2.1.1"
     }
 }
 rootProject {


### PR DESCRIPTION
Fixes class cast exception in Gradle 7.6 and above.

fixes #2 
closes dorongold/gradle-task-tree#53